### PR TITLE
Fix sources dump for symfony version == 4.4.x

### DIFF
--- a/eos/core/symfony.py
+++ b/eos/core/symfony.py
@@ -139,7 +139,7 @@ class Symfony(Base):
 
         if self.version <= '4.1':
             container = f'{root}{env}{debug}ProjectContainer'
-        elif self.version <= '4.4':
+        elif self.version < '4.5':
             container = f'{root}{cls}{env}{debug}Container'
         else:
             container = f'{cls}{env}{debug}Container'


### PR DESCRIPTION
Fixing version parsing for version `4.4.X`

Related bug: 
![image](https://user-images.githubusercontent.com/10145128/207096956-2e318fc3-7cd7-49c9-8baa-57aea693c11e.png)

This quick fix handle `4.4.x` versions of Symfony.